### PR TITLE
Improving ghostscript detection (windows)

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -68,7 +68,7 @@ if options["target"] == "testpkg" then
   print("** Running: perl -cw "..pdfcrop)
   errorlevel = run(tmpdir, "perl -cw "..pdfcrop)
   if errorlevel ~= 0 then
-    error("** Error!!: perl -cw "..script)
+    error("** Error!!: perl -cw "..pdfcrop)
     return errorlevel
   end
   -- Copy test files
@@ -90,7 +90,7 @@ if options["target"] == "testpkg" then
   if errorlevel ~= 0 then
     error("** Error!!: Can't copy files from ./"..tmpdir.." to "..maindir)
   end
-  -- If are OK, clean files and temp dir
+  -- If are OK, clean files and remove temp dir
   print("** Remove temporary directory ./"..tmpdir)
   cleandir(tmpdir)
   lfs.rmdir(tmpdir)

--- a/build.lua
+++ b/build.lua
@@ -1,16 +1,15 @@
 #!/usr/bin/env texlua
 
-
 module = "pdfcrop"
 
+maindir = "."
 textfiles = {"README.md","LICENCE"}
 sourcefiles = {"pdfcrop.pl"}
-installfiles={"*.pl"}
-scriptfiles={"*.pl"}
-ctanreadme ="README.md"
- 
-packtdszip  = false
+installfiles = {"*.pl"}
+scriptfiles = {"*.pl"}
+ctanreadme = "README.md"
 
+packtdszip = false
 
 function update_tag(file,content,tagname,tagdate)
 
@@ -38,4 +37,58 @@ end
 
 end
 
+-- Create make_temp_dir() function
+local function make_temp_dir()
+  local tmpname = os.tmpname()
+  tempdir = basename(tmpname)
+  print("** Creating the temporary directory ./"..tempdir)
+  errorlevel = mkdir(tempdir)
+  if errorlevel ~= 0 then
+    error("** Error!!: The ./"..tempdir.." directory could not be created")
+    return errorlevel
+  end
+end
 
+-- Add "testpkg" target to l3build CLI
+if options["target"] == "testpkg" then
+  make_temp_dir()
+  -- Copy script
+  local pdfcrop = "pdfcrop.pl"
+  print("** Copying "..pdfcrop.." from "..maindir.." to ./"..tempdir)
+  errorlevel = cp(pdfcrop, maindir, tempdir)
+  if errorlevel ~= 0 then
+    error("** Error!!: Can't copy "..pdfcrop.." from "..maindir.." to /"..tempdir)
+    return errorlevel
+  end
+  -- Check syntax
+  print("** Running: perl -cw "..pdfcrop)
+  errorlevel = run(tempdir, "perl -cw "..pdfcrop)
+  if errorlevel ~= 0 then
+    error("** Error!!: perl -cw "..script)
+    return errorlevel
+  end
+  -- Copy test files
+  print("** Copying files from ./tests to ./"..tempdir)
+  errorlevel = cp("*.*", "./tests", tempdir)
+  if errorlevel ~= 0 then
+    error("** Error!!: Can't copy files from ./tests to /"..tempdir)
+  end
+  -- Run a simple test
+  print("** Running: perl "..pdfcrop.." --luatex --margins 0 version-test.pdf")
+  errorlevel = run(tempdir, "perl "..pdfcrop.." --luatex --margins 0 version-test.pdf")
+  if errorlevel ~= 0 then
+    error("** Error!!: perl "..pdfcrop.." --luatex --margins 0 version-test.pdf")
+    return errorlevel
+  end
+  -- We can copy the output or do other operations
+  print("** Copying result from ./"..tempdir.." to "..maindir)
+  errorlevel = cp("*-crop.pdf", tempdir, maindir)
+  if errorlevel ~= 0 then
+    error("** Error!!: Can't copy files from ./"..tempdir.." to "..maindir)
+  end
+  -- Clean files
+  print("** Remove temporary directory ./"..tempdir)
+  --cleandir(tempdir)
+  --lfs.rmdir(tempdir)
+  os.exit()
+end

--- a/pdfcrop.pl
+++ b/pdfcrop.pl
@@ -168,19 +168,19 @@ sub find_ghostscript () {
     $system = 'win' if $^O =~ /mswin32/i;
     $system = 'cygwin' if $^O =~ /cygwin/i;
     $system = 'msys' if $^O =~ /msys/i;
-    $system = 'miktex' if defined $ENV{"TEXSYSTEM"} and
-                          $ENV{"TEXSYSTEM"} =~ /miktex/i;
+    $system = 'miktex' if defined $ENV{'TEXSYSTEM'} and
+                          $ENV{'TEXSYSTEM'} =~ /miktex/i;
     print "* OS name: $^O\n" if $::opt_debug;
     print "* Arch name: $archname\n" if $::opt_debug;
     print "* System: $system\n" if $::opt_debug;
     my %candidates = (
         'unix' => [qw|gs gsc|],
-        'dos' => [qw|gs386 gs|],
+        'dos' => [qw|gs386|],
         'os2' => [qw|gsos2 gs|],
-        'win' => [qw|gswin32c gs|],
+        'win' => [qw|gswin32c|],
         'msys'   => [qw|gswin32c gswin64c|],
         'cygwin' => [qw|gs|],
-        'miktex' => [qw|mgs gswin32c gs|]
+        'miktex' => [qw|mgs gswin32c|]
     );
     if ($system eq 'win' or $system eq 'miktex') {
         if ($archname =~ /mswin32-x64/i) {
@@ -321,7 +321,7 @@ sub SearchRegistry () {
 
 ### This part is only necessary if you're using Git on windows and don't
 ### have gs configured in PATH. Git for windows don't have a Win32::TieRegistry
-### module fro perl (is not supported in the current versions of msys).
+### module for perl (is not supported in the current versions of msys).
 sub Searchbyregquery (){
     use Env qw(PATH);
     my $found = 0;

--- a/pdfcrop.pl
+++ b/pdfcrop.pl
@@ -18,9 +18,9 @@ $^W=1; # turn warning on
 my $prj         = 'pdfcrop';
 my $file        = "$prj.pl";
 my $program     = uc($&) if $file =~ /^\w+/;
-my $version     = "1.40";
-my $date        = "2020/06/06";
-my $author      = "Heiko Oberdiek, Oberdiek Package Support Group";
+my $version     = '1.40';
+my $date        = '2020/06/06';
+my $author      = 'Heiko Oberdiek, Oberdiek Package Support Group';
 my $copyright   = "Copyright (c) 2002-2020 by $author.";
 #
 # Reqirements: Perl5, Ghostscript
@@ -106,7 +106,7 @@ my $copyright   = "Copyright (c) 2002-2020 by $author.";
 # 2020/05/24 v1.39: * adapted to pdfversion 2.0, corrected luatex support,
 #                      corrected a problem with xetex.
 # 2020/06/06 v1.40: * improved ghostscript detection on windows when a bash is used
-#                      added direct pdf version support to xetex. 
+#                      added direct pdf version support to xetex.
 
 
 
@@ -114,7 +114,7 @@ my $copyright   = "Copyright (c) 2002-2020 by $author.";
 my $title = "$program $version, $date - $copyright\n";
 
 ### error strings
-my $Error = "!!! Error:"; # error prefix
+my $Error = '!!! Error:'; # error prefix
 
 ### make ENV safer
 delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
@@ -122,7 +122,7 @@ delete @ENV{qw(IFS CDPATH ENV BASH_ENV)};
 # Windows detection (no SIGHUP)
 my $Win = 0;
 $Win = 1 if $^O =~ /mswin32/i;
-$Win = 1 if $^O =~ /cygwin/i;
+
 use Config;
 my $archname = $Config{'archname'};
 $archname = 'unknown' unless defined $Config{'archname'};
@@ -163,24 +163,26 @@ sub find_ghostscript () {
                 (defined($Config{'d_fork'}) ? 'yes' : 'no');
     }
     my $system = 'unix';
-    $system = "dos" if $^O =~ /dos/i;
-    $system = "os2" if $^O =~ /os2/i;
-    $system = "win" if $^O =~ /mswin32/i;
-    $system = "cygwin" if $^O =~ /cygwin/i;
-    $system = "miktex" if defined($ENV{"TEXSYSTEM"}) and
+    $system = 'dos' if $^O =~ /dos/i;
+    $system = 'os2' if $^O =~ /os2/i;
+    $system = 'win' if $^O =~ /mswin32/i;
+    $system = 'cygwin' if $^O =~ /cygwin/i;
+    $system = 'msys' if $^O =~ /msys/i;
+    $system = 'miktex' if defined $ENV{"TEXSYSTEM"} and
                           $ENV{"TEXSYSTEM"} =~ /miktex/i;
     print "* OS name: $^O\n" if $::opt_debug;
     print "* Arch name: $archname\n" if $::opt_debug;
     print "* System: $system\n" if $::opt_debug;
     my %candidates = (
-        'unix' => [qw|gs gsc gswin64c gswin32c|],
+        'unix' => [qw|gs gsc|],
         'dos' => [qw|gs386 gs|],
         'os2' => [qw|gsos2 gs|],
         'win' => [qw|gswin32c gs|],
-        'cygwin' => [qw|gs gswin32c|],
+        'msys'   => [qw|gswin32c gswin64c|],
+        'cygwin' => [qw|gs|],
         'miktex' => [qw|mgs gswin32c gs|]
     );
-    if ($system eq 'win' or $system eq 'cygwin' or $system eq 'miktex') {
+    if ($system eq 'win' or $system eq 'miktex') {
         if ($archname =~ /mswin32-x64/i) {
             my @a = ();
             foreach my $name (@{$candidates{$system}}) {
@@ -195,6 +197,7 @@ sub find_ghostscript () {
         'dos' => '.exe',
         'os2' => '.exe',
         'win' => '.exe',
+        'msys'   => '.exe',
         'cygwin' => '.exe',
         'miktex' => '.exe'
     );
@@ -220,6 +223,9 @@ sub find_ghostscript () {
     if (not $found and $Win) {
         $found = SearchRegistry();
     }
+    if (not $found and $system eq 'msys') {
+        $found = Searchbyregquery();
+    }
     if ($found) {
         print "* Autodetected ghostscript command: $::opt_gscmd\n" if $::opt_debug;
     }
@@ -231,7 +237,8 @@ sub find_ghostscript () {
 
 sub SearchRegistry () {
     my $found = 0;
-    eval 'use Win32::TieRegistry qw|KEY_READ REG_SZ|;';
+    # The module Win32::TieRegistry not aviable in cygwin and msys (git win)
+    eval 'use Win32::TieRegistry qw|KEY_READ REG_SZ|';
     if ($@) {
         if ($::opt_debug) {
             print "* Registry lookup for Ghostscript failed:\n";
@@ -308,6 +315,61 @@ sub SearchRegistry () {
         print "* Found (via registry): $::opt_gscmd\n" if $::opt_debug;
         $found = 1;
         last;
+    }
+    return $found;
+}
+
+### This part is only necessary if you're using Git on windows and don't
+### have gs configured in PATH. Git for windows don't have a Win32::TieRegistry
+### module fro perl (is not supported in the current versions of msys).
+sub Searchbyregquery (){
+    use Env qw(PATH);
+    my $found = 0;
+    my $gs_regkey;
+    my $opt_reg = '//s //v';
+    print "* Search Ghostscript in Windows registry under msys:\n" if $::opt_debug;
+    # search for x64 version key in reg
+    $gs_regkey = qx{reg query "HKLM\\Software\\GPL Ghostscript" $opt_reg GS_DLL};
+    if ($? == 0) {
+        print "* Registry entry found for GS_DLL (64 bits version)\n" if $::opt_debug;
+    }
+    else {
+        # search for x32 version key in reg
+        $gs_regkey = qx{reg query "HKLM\\Software\\Wow6432Node\\GPL Ghostscript" $opt_reg GS_DLL};
+        if ($? == 0) {
+            print "* Registry entry found for GS_DLL (32 bits version)\n" if $::opt_debug;
+        }
+    }
+    my ($gs_find) = $gs_regkey =~ m/(?:\s* GS_DLL \s* REG_SZ \s*) (.+?)(?:\.dll.+?\R)/s;
+    if ($gs_find) {
+        my ($gs_vol, $gs_path, $gs_ver) = $gs_find =~ m/
+                                                        (\w{1})(?:\:)   # volumen
+                                                        (.+?)           # path to executable
+                                                        (?:\\gsdll)     # LIB
+                                                        (\d{2})         # Version
+                                                      /xs;
+        # Adjust
+        $gs_vol = lc($gs_vol);
+        $gs_path = '/'.$gs_vol.$gs_path;
+        $gs_path =~ s|\\|/|gmsxi;
+        # Add to PATH
+        print "* Add $gs_path to PATH for current session\n" if $::opt_debug;
+        $PATH .= ":$gs_path";
+        # Set executable
+        $::opt_gscmd = 'gswin'.$gs_ver.'c';
+        print "* Found (via reg query): $::opt_gscmd\n" if $::opt_debug;
+        $found = 1;
+    }
+    if ($@) {
+        if ($::opt_debug) {
+            print "* Registry lookup for Ghostscript by reg query failed:\n";
+            my $msg = $@;
+            $msg =~ s/\s+$//;
+            foreach (split /\r?\n/, $msg) {
+                print " $_\n";
+            }
+        }
+        return $found;
     }
     return $found;
 }
@@ -411,8 +473,8 @@ Expert options:
                       of the input PDF file.
                       An empty value or `none' uses the
                       default of the TeX engine.               ($::opt_pdfversion)
-  --uncompress        creates an uncompressed pdf, 
-                      useful for debugging                     ($bool[$::opt_uncompress])                     
+  --uncompress        creates an uncompressed pdf,
+                      useful for debugging                     ($bool[$::opt_uncompress])
 
 Input file: If the name is `-', then the standard input is used and
   the output file name must be explicitly given.
@@ -836,7 +898,7 @@ END_TMP
 
 my $uncompress = $::opt_uncompress ? '0 ' : '9 ';
 if ($::opt_tex eq 'pdftex') {
- print TMP "\\pdfcompresslevel=$uncompress "; 
+ print TMP "\\pdfcompresslevel=$uncompress ";
     print TMP <<'END_TMP_HEAD';
 \pdfoutput=1 %
 \csname pdfmapfile\endcsname{}
@@ -849,7 +911,7 @@ if ($::opt_tex eq 'pdftex') {
      \else
        \pdfobjcompresslevel=2 %
      \fi
-   \fi 
+   \fi
   }%
   \IfUndefined{pdfminorversion}{%
     \IfUndefined{pdfoptionpdfminorversion}{%
@@ -920,7 +982,7 @@ END_TMP_HEAD
 }
 elsif  ($::opt_tex eq 'luatex')
   {
-    print TMP "\\pdfvariable compresslevel=$uncompress "; 
+    print TMP "\\pdfvariable compresslevel=$uncompress ";
     print TMP <<'END_TMP_HEAD';
 \outputmode=1 %
 \pdfextension mapfile {}
@@ -931,9 +993,9 @@ elsif  ($::opt_tex eq 'luatex')
      \else
        \pdfvariable objcompresslevel=2 %
      \fi
-    \fi  
+    \fi
     \pdfvariable minorversion= #2
-    \pdfvariable majorversion= #1 
+    \pdfvariable majorversion= #1
 }
 \def\page #1 [#2 #3 #4 #5]{%
   \count0=#1\relax
@@ -988,8 +1050,8 @@ elsif  ($::opt_tex eq 'luatex')
   }%
 }
 END_TMP_HEAD
-    print TMP "\\setpdfversion{$::opt_pdfmajorversion}{$::opt_pdfminorversion}\n" if $::opt_pdfversion;    
-}  
+    print TMP "\\setpdfversion{$::opt_pdfmajorversion}{$::opt_pdfminorversion}\n" if $::opt_pdfversion;
+}
 else { # XeTeX
     print TMP <<'END_TMP_HEAD';
 \expandafter\ifx\csname XeTeXpdffile\endcsname\relax
@@ -998,7 +1060,7 @@ else { # XeTeX
 \def\setpdfversion#1#2{%
   \special{pdf:majorversion #1}%
   \special{pdf:minorversion #2}}
-  
+
 \def\page #1 [#2 #3 #4 #5]{%
   \count0=#1\relax
   \setbox0=\hbox{%
@@ -1039,7 +1101,7 @@ else { # XeTeX
   }%
 }
 END_TMP_HEAD
-print TMP "\\setpdfversion{$::opt_pdfmajorversion}{$::opt_pdfminorversion}\n" if $::opt_pdfversion; 
+print TMP "\\setpdfversion{$::opt_pdfmajorversion}{$::opt_pdfminorversion}\n" if $::opt_pdfversion;
 }
 
 print "* Running ghostscript for BoundingBox calculation ...\n"


### PR DESCRIPTION
* The `SearchRegistry` function call was removed under `cygwin`
* Added `Searchbyregquery` function to detect gs executable under `msys` (git bash)
* Some double quotes were changed to single quotes
* Remove some old names for `gs` (reduce time to autodetect)
* Add a sample for test in `build.lua`

To do the tests I used

```
perl pdfcrop.pl --debug tests/version-test.pdf
```

The output under msys without having gs in PATH:
```
PDFCROP 1.40, 2020/06/06 - Copyright (c) 2002-2020 by Heiko Oberdiek, Oberdiek Package Support Group.
* Restricted mode: disabled
* Option `pdfversion': auto
* Perl executable: perl
* Perl version: v5.30.2
* Pointer size: 8
* Pipe support: yes
* Fork support: yes
* OS name: msys
* Arch name: x86_64-msys-thread-multi
* System: msys
* Not found (gswin32c): /c/Users/pablo/bin/gswin32c.exe
* Not found (gswin32c): /mingw64/bin/gswin32c.exe
* Not found (gswin32c): /usr/local/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/gswin32c.exe
* Not found (gswin32c): /bin/gswin32c.exe
* Not found (gswin32c): /mingw64/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/gswin32c.exe
* Not found (gswin32c): /c/Users/pablo/bin/gswin32c.exe
* Not found (gswin32c): /c/Windows/system32/gswin32c.exe
* Not found (gswin32c): /c/Windows/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/Wbem/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/WindowsPowerShell/v1.0/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/OpenSSH/gswin32c.exe
* Not found (gswin32c): /c/ProgramData/chocolatey/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/c/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/perl/site/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/perl/bin/gswin32c.exe
* Not found (gswin32c): /cmd/gswin32c.exe
* Not found (gswin32c): /c/tools/BCURRAN3/gswin32c.exe
* Not found (gswin32c): /c/Users/pablo/AppData/Local/Microsoft/WindowsApps/gswin32c.exe
* Not found (gswin32c): /c/texlive/2020/bin/win32/gswin32c.exe
* Not found (gswin32c): /d/jdk/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/vendor_perl/gswin32c.exe
* Not found (gswin32c): /usr/bin/core_perl/gswin32c.exe
* Not found (gswin64c): /c/Users/pablo/bin/gswin64c.exe
* Not found (gswin64c): /mingw64/bin/gswin64c.exe
* Not found (gswin64c): /usr/local/bin/gswin64c.exe
* Not found (gswin64c): /usr/bin/gswin64c.exe
* Not found (gswin64c): /bin/gswin64c.exe
* Not found (gswin64c): /mingw64/bin/gswin64c.exe
* Not found (gswin64c): /usr/bin/gswin64c.exe
* Not found (gswin64c): /c/Users/pablo/bin/gswin64c.exe
* Not found (gswin64c): /c/Windows/system32/gswin64c.exe
* Not found (gswin64c): /c/Windows/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/Wbem/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/WindowsPowerShell/v1.0/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/OpenSSH/gswin64c.exe
* Not found (gswin64c): /c/ProgramData/chocolatey/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/c/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/perl/site/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/perl/bin/gswin64c.exe
* Not found (gswin64c): /cmd/gswin64c.exe
* Not found (gswin64c): /c/tools/BCURRAN3/gswin64c.exe
* Not found (gswin64c): /c/Users/pablo/AppData/Local/Microsoft/WindowsApps/gswin64c.exe
* Not found (gswin64c): /c/texlive/2020/bin/win32/gswin64c.exe
* Not found (gswin64c): /d/jdk/bin/gswin64c.exe
* Not found (gswin64c): /usr/bin/vendor_perl/gswin64c.exe
* Not found (gswin64c): /usr/bin/core_perl/gswin64c.exe
* Search Ghostscript in Windows registry under msys:
* Registry entry found for GS_DLL (64 bits version)
* Add /c/Program Files/gs/gs9.52/bin to PATH for current session
* Found (via reg query): gswin64c
* Autodetected ghostscript command: gswin64c
* Input file: tests/version-test.pdf
* Output file: tests/version-test-crop.pdf
* Margins: 0 0 0 0
* PDF header: %PDF-2.0
* Using PDF version: 2.0
* Running ghostscript for BoundingBox calculation ...
* Ghostscript call: gswin64c -sDEVICE=bbox -dBATCH -dNOPAUSE -c save pop -f tests/version-test.pdf
GPL Ghostscript 9.52 (2020-03-19)
Copyright (C) 2020 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Processing pages 1 through 1.
Page 1
%%BoundingBox: 149 139 308 715
* Page 1: 149 139 308 715
%%HiResBoundingBox: 149.003995 139.247996 307.295991 714.023978
* Running pdfTeX ...
* pdfTeX call: pdftex -no-shell-escape -interaction=nonstopmode tmp-pdfcrop-1229
This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020/W32TeX) (preloaded format=pdftex)
entering extended mode
(./tmp-pdfcrop-1229.tex [1 <./tests/version-test.pdf>] )
Output written on tmp-pdfcrop-1229.pdf (1 page, 11071 bytes).
Transcript written on tmp-pdfcrop-1229.log.
==> 1 page written on `tests/version-test-crop.pdf'.
* Cleanup
* Temporary files: tmp-pdfcrop-1229.tex tmp-pdfcrop-1229.log
```

The output under msys having gs in PATH:
```
PDFCROP 1.40, 2020/06/06 - Copyright (c) 2002-2020 by Heiko Oberdiek, Oberdiek Package Support Group.
* Restricted mode: disabled
* Option `pdfversion': auto
* Perl executable: perl
* Perl version: v5.30.2
* Pointer size: 8
* Pipe support: yes
* Fork support: yes
* OS name: msys
* Arch name: x86_64-msys-thread-multi
* System: msys
* Not found (gswin32c): /c/Users/pablo/bin/gswin32c.exe
* Not found (gswin32c): /mingw64/bin/gswin32c.exe
* Not found (gswin32c): /usr/local/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/gswin32c.exe
* Not found (gswin32c): /bin/gswin32c.exe
* Not found (gswin32c): /mingw64/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/gswin32c.exe
* Not found (gswin32c): /c/Users/pablo/bin/gswin32c.exe
* Not found (gswin32c): /c/Windows/system32/gswin32c.exe
* Not found (gswin32c): /c/Windows/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/Wbem/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/WindowsPowerShell/v1.0/gswin32c.exe
* Not found (gswin32c): /c/Windows/System32/OpenSSH/gswin32c.exe
* Not found (gswin32c): /c/ProgramData/chocolatey/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/c/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/perl/site/bin/gswin32c.exe
* Not found (gswin32c): /c/Strawberry/perl/bin/gswin32c.exe
* Not found (gswin32c): /cmd/gswin32c.exe
* Not found (gswin32c): /c/tools/BCURRAN3/gswin32c.exe
* Not found (gswin32c): /c/Users/pablo/AppData/Local/Microsoft/WindowsApps/gswin32c.exe
* Not found (gswin32c): /c/texlive/2020/bin/win32/gswin32c.exe
* Not found (gswin32c): /d/jdk/bin/gswin32c.exe
* Not found (gswin32c): /c/Program Files/gs/gs9.52/bin/gswin32c.exe
* Not found (gswin32c): /usr/bin/vendor_perl/gswin32c.exe
* Not found (gswin32c): /usr/bin/core_perl/gswin32c.exe
* Not found (gswin64c): /c/Users/pablo/bin/gswin64c.exe
* Not found (gswin64c): /mingw64/bin/gswin64c.exe
* Not found (gswin64c): /usr/local/bin/gswin64c.exe
* Not found (gswin64c): /usr/bin/gswin64c.exe
* Not found (gswin64c): /bin/gswin64c.exe
* Not found (gswin64c): /mingw64/bin/gswin64c.exe
* Not found (gswin64c): /usr/bin/gswin64c.exe
* Not found (gswin64c): /c/Users/pablo/bin/gswin64c.exe
* Not found (gswin64c): /c/Windows/system32/gswin64c.exe
* Not found (gswin64c): /c/Windows/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/Wbem/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/WindowsPowerShell/v1.0/gswin64c.exe
* Not found (gswin64c): /c/Windows/System32/OpenSSH/gswin64c.exe
* Not found (gswin64c): /c/ProgramData/chocolatey/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/c/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/perl/site/bin/gswin64c.exe
* Not found (gswin64c): /c/Strawberry/perl/bin/gswin64c.exe
* Not found (gswin64c): /cmd/gswin64c.exe
* Not found (gswin64c): /c/tools/BCURRAN3/gswin64c.exe
* Not found (gswin64c): /c/Users/pablo/AppData/Local/Microsoft/WindowsApps/gswin64c.exe
* Not found (gswin64c): /c/texlive/2020/bin/win32/gswin64c.exe
* Not found (gswin64c): /d/jdk/bin/gswin64c.exe
* Found (gswin64c): /c/Program Files/gs/gs9.52/bin/gswin64c.exe
* Autodetected ghostscript command: gswin64c
* Input file: tests/version-test.pdf
* Output file: tests/version-test-crop.pdf
* Margins: 0 0 0 0
* PDF header: %PDF-2.0
* Using PDF version: 2.0
* Running ghostscript for BoundingBox calculation ...
* Ghostscript call: gswin64c -sDEVICE=bbox -dBATCH -dNOPAUSE -c save pop -f tests/version-test.pdf
GPL Ghostscript 9.52 (2020-03-19)
Copyright (C) 2020 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Processing pages 1 through 1.
Page 1
%%BoundingBox: 149 139 308 715
* Page 1: 149 139 308 715
%%HiResBoundingBox: 149.003995 139.247996 307.295991 714.023978
* Running pdfTeX ...
* pdfTeX call: pdftex -no-shell-escape -interaction=nonstopmode tmp-pdfcrop-831
This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020/W32TeX) (preloaded format=pdftex)
entering extended mode
(./tmp-pdfcrop-831.tex [1 <./tests/version-test.pdf>] )
Output written on tmp-pdfcrop-831.pdf (1 page, 11071 bytes).
Transcript written on tmp-pdfcrop-831.log.
==> 1 page written on `tests/version-test-crop.pdf'.
* Cleanup
* Temporary files: tmp-pdfcrop-831.tex tmp-pdfcrop-831.log
```

The output under cygwin:
```
PDFCROP 1.40, 2020/06/06 - Copyright (c) 2002-2020 by Heiko Oberdiek, Oberdiek Package Support Group.
* Restricted mode: disabled
* Option `pdfversion': auto
* Perl executable: /usr/bin/perl
* Perl version: v5.30.3
* Pointer size: 8
* Pipe support: yes
* Fork support: yes
* OS name: cygwin
* Arch name: x86_64-cygwin-threads-multi
* System: cygwin
* Not found (gs): /usr/local/bin/gs.exe
* Found (gs): /usr/bin/gs.exe
* Autodetected ghostscript command: gs
* Input file: tests/version-test.pdf
* Output file: tests/version-test-crop.pdf
* Margins: 0 0 0 0
* PDF header: %PDF-2.0
* Using PDF version: 2.0
* Running ghostscript for BoundingBox calculation ...
* Ghostscript call: gs -sDEVICE=bbox -dBATCH -dNOPAUSE -c save pop -f tests/version-test.pdf
GPL Ghostscript 9.52 (2020-03-19)
Copyright (C) 2020 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Processing pages 1 through 1.
Page 1
%%BoundingBox: 149 139 308 715
* Page 1: 149 139 308 715
%%HiResBoundingBox: 149.003995 139.247996 307.295991 714.023978
* Running pdfTeX ...
* pdfTeX call: pdftex -no-shell-escape -interaction=nonstopmode tmp-pdfcrop-759
This is pdfTeX, Version 3.14159265-2.6-1.40.21 (TeX Live 2020/W32TeX) (preloaded format=pdftex)
entering extended mode
(./tmp-pdfcrop-759.tex [1 <./tests/version-test.pdf>] )
Output written on tmp-pdfcrop-759.pdf (1 page, 11071 bytes).
Transcript written on tmp-pdfcrop-759.log.
==> 1 page written on `tests/version-test-crop.pdf'.
* Cleanup
* Temporary files: tmp-pdfcrop-759.tex tmp-pdfcrop-759.log
```

I have left in comments the changes I have added, the changes only affect users who use `perl pdfcrop` and not those who use the direct version provided in TeXLive.

~~You can remove the detection of some old architectures (`dos`, `os2`) and some executable names for gs (`gsc`, `gs386`, `gsos2`), but, I don't know what level of backwards compatibility you want to have.~~

~~One thing I didn't manage to test was to remove `gs` from the list of ghostscript executable names for miktex (and windows), if anyone has miktex they might be able to do the test.~~