### PR TITLE
Permission error occurs in Windows OS

### DIFF
--- a/pdfcrop.pl
+++ b/pdfcrop.pl
@@ -707,7 +707,7 @@ elsif (not $inputfile =~ /^[\w\d\.\-\:\/@]+$/) { # /[\s\$~'"#{}%]/
           . "* " . ($symlink_exists ? "Link" : "Copy")
           . " input file to temporary file `$inputfilesafe'.\n"
             if $::opt_verbose;
-    if ($symlink_exists) {
+    if (not $Win and $symlink_exists) {
         symlink($inputfile, $inputfilesafe)
             or die sprintf "$Error Link from `%s' to `%s' failed (%s)!\n",
                            $inputfile, $inputfilesafe, exterr;


### PR DESCRIPTION
Permission error occurs in Windows OS as follows. 

```powershell
> pdfcrop.exe .\figures.pdf
PDFCROP 1.40, 2020/06/06 - Copyright (c) 2002-2020 by Heiko Oberdiek, Oberdiek Package Support Group.
!!! Error: Link from `.\figures.pdf' to `tmp-pdfcrop-25824-img.pdf' failed (Operation not permitted/クライアントは要求された特権を保有していません。)!
C:\texlive\2022\bin\win32\runscript.tlu:915: command failed with exit code 2:
perl.exe c:\texlive\2022\texmf-dist\scripts\pdfcrop\pdfcrop.pl .\figures.pdf 
```

I am using 
- Windows 10 Pro 22H2
- PowerShell 5.1.19041.2364
- TeX Live 2022
- pdfcrop 1.40.

I think the `symlink` command in [l.711](https://github.com/ho-tex/pdfcrop/blob/2ad5497487c78802f3dea0e86ff287deba414a22/pdfcrop.pl#L711) is the cause of the error. Because Windows OS required administrator permission to create symbolic links.

It seems that pdfcrop.pl has the feature to switch `symlink` command to `copy` command using `$symlink_exists`. However, I guess the feature does not work well. Therefore, I suggest we should switch to `copy` command in Windows OS regardless of `$symlink_exists`. 